### PR TITLE
Publish JAR instead of AAR

### DIFF
--- a/fragments/build.gradle.kts
+++ b/fragments/build.gradle.kts
@@ -51,7 +51,8 @@ configure<PublishingExtension> {
   publications {
     create<MavenPublication>("default") {
       afterEvaluate {
-        from(components["release"])
+//        from(components["release"])
+        artifact("${layout.buildDirectory.get().asFile}/intermediates/aar_main_jar/release/classes.jar")
       }
     }
   }


### PR DESCRIPTION
This would be similar to our setup. The error message is similar. EXcept, in this setup it is completely missing `.module` file, I don't know why.

```
1: Task failed with an exception.
-----------
* What went wrong:
Execution failed for task ':consumer:generateService1ApolloOptions'.
> Could not resolve all files for configuration ':consumer:apolloService1OtherOptionsResolvable'.
   > Could not resolve com.fragments:fragments:1.0.0.
     Required by:
         project :consumer
      > No matching variant of com.fragments:fragments:1.0.0 was found. The consumer was configured to find a component for use during 'OtherOptions', as well as attribute 'com.apollographql.direction' with value 'Upstream', attribute 'com.apollographql.service' with value 'service1' but:
          - Variant 'compile':
              - Incompatible because this component declares a component for use during compile-time and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'enforced-platform-compile':
              - Incompatible because this component declares a component for use during compile-time and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'enforced-platform-runtime':
              - Incompatible because this component declares a component for use during runtime and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'javadoc':
              - Incompatible because this component declares a component for use during runtime and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'platform-compile':
              - Incompatible because this component declares a component for use during compile-time and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'platform-runtime':
              - Incompatible because this component declares a component for use during runtime and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'runtime':
              - Incompatible because this component declares a component for use during runtime and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')
          - Variant 'sources':
              - Incompatible because this component declares a component for use during runtime and the consumer needed a component for use during 'OtherOptions'
              - Other compatible attributes:
                  - Doesn't say anything about com.apollographql.direction (required 'Upstream')
                  - Doesn't say anything about com.apollographql.service (required 'service1')

```